### PR TITLE
Slow mech pickups and scrolling leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,13 +118,13 @@
       }
     }
 
-    // fetch top-10
+    // fetch top-50
     async function fetchTopGlobalScores() {
       try {
         const q    = query(
           collection(db, "leaderboard"),
           orderBy("score","desc"),
-          limit(10)
+          limit(50)
         );
         const snap = await getDocs(q);
         return snap.docs.map(d => d.data());
@@ -132,7 +132,7 @@
         console.warn("Firestore read failed…", e);
         return JSON.parse(localStorage.getItem('birdyHighScores')||'[]')
                      .sort((a,b)=>b.score - a.score)
-                     .slice(0,10);
+                     .slice(0,50);
       }
     }
 
@@ -216,7 +216,7 @@ const tossBombs   = [];   // upward‐toss bombs
   let hasSubmittedScore = false;
   let overlayTop10Lock  = false;
 
-  // click-outside: auto-save once, then only close if NOT top-10
+  // click-outside: auto-save once, then only close if NOT top-50
   overlay.addEventListener('click', e => {
     if (e.target === overlay) {
       if (!hasSubmittedScore) {
@@ -1300,7 +1300,8 @@ function updateJellies() {
   // ── coin pickup (your existing code) ──
   coins.forEach((c, i) => {
   // move
-  c.x -= currentSpeed;
+  const coinSpeed = currentSpeed * (inMecha ? 0.33 : 1);
+  c.x -= coinSpeed;
 
   if (!c.taken) {
     // draw spinning coin…
@@ -1340,7 +1341,8 @@ function updateJellies() {
 
   // ── triple rocket powerup pickup ──
   rocketPowerups.forEach((p,i)=>{
-    p.x -= currentSpeed * 0.6;
+    const powerSpeed = currentSpeed * 0.6 * (inMecha ? 0.33 : 1);
+    p.x -= powerSpeed;
     if(!p.taken){
       ctx.save();
       ctx.translate(p.x, p.y + Math.sin(frames*0.1)*2);
@@ -1499,16 +1501,16 @@ function handleHit(){
    // ── 3) GAME OVER / LEADERBOARD ──────────────────────────────
 
 
-// showOverlay: ask for name only if you made top-10
+// showOverlay: ask for name only if you made top-50
 // ── 3) GAME OVER / LEADERBOARD ──────────────────────────────
 
 // showOverlay: ALWAYS ask for a name, regardless of global standing
   async function showOverlay() {
     // cancel any leftover auto-hide from a boss-defeat popup
     clearTimeout(achievementHideTimer);
-    // compute whether this score belongs in top-10
+    // compute whether this score belongs in top-50
     const top = await fetchTopGlobalScores();
-    const lowestTopScore = top.length < 10
+    const lowestTopScore = top.length < 50
       ? -Infinity
       : top[top.length - 1].score;
     overlayTop10Lock = score >= lowestTopScore;
@@ -1538,16 +1540,35 @@ function handleHit(){
 
 
 // showHighScores: display list + Play Again button
-function showHighScores(hs){
+function showHighScores(hs, autoScroll = false){
   const ct = document.getElementById('gameOverContent');
-  let html = `<h2>Top 10</h2><ol style="text-align:left;display:inline-block;">`;
+  let html = `<h2>Top 50</h2>` +
+             `<div id="hsBox" style="height:200px;overflow:hidden;">` +
+             `<ol id="hsList" style="text-align:left;margin:0;padding-left:20px;">`;
   hs.forEach(i => html += `<li>${i.name} — ${i.score}</li>`);
-  html += `</ol><br/><button id="retryBtn">Play Again</button>`;
+  html += `</ol></div><br/><button id="retryBtn">Play Again</button>`;
   ct.innerHTML = html;
   document.getElementById('retryBtn').onclick = () => {
     document.getElementById('overlay').style.display = 'none';
     resetGame();
   };
+
+  if(autoScroll){
+    const box  = document.getElementById('hsBox');
+    const max  = box.scrollHeight - box.clientHeight;
+    let dir    = 1;
+    let pos    = 0;
+    setTimeout(()=>{
+      function step(){
+        pos += dir * 0.3;
+        if(pos >= max){ pos = max; dir = -1; }
+        if(pos <= 0){ pos = 0; dir = 1; }
+        box.scrollTop = pos;
+        if(document.getElementById('hsBox')) requestAnimationFrame(step);
+      }
+      requestAnimationFrame(step);
+    }, 2000);
+  }
 }
 function showAchievement(message, duration = 2000) {
     // clear any previous hide-timer
@@ -1829,7 +1850,7 @@ if (state === STATE.Play) {
       const ov = document.getElementById('overlay');
       ov.style.display = 'block';
       // …and fill it with the board
-      showHighScores(hs);
+      showHighScores(hs, true);
     });
 
   })();


### PR DESCRIPTION
## Summary
- slow down coins and rocket pickups when in Mecha mode
- expand global leaderboard to top 50 players
- add auto-scrolling behaviour to leaderboard at start

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6842ffa5b1a88329a5fe821f927fc102