### PR TITLE
Fix mobile layout and leaderboard numbering

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,11 +58,7 @@
   </script>
   <!-- ────────────────────────────────── -->
 
-  <audio id="bgMusic"
-         src="assets/dream.guitar.mp3"
-         loop
-         preload="metadata"></audio>
-  <!-- …the rest of your code… -->
+
 
   <audio id="bgMusic"
        src="assets/dream.guitar.mp3"
@@ -274,7 +270,10 @@ document.addEventListener('keydown',   initMusic, {passive:true});
       overlay.style.paddingTop = (headerH + 20) + 'px';
     }
     window.addEventListener('resize', resizeCanvas);
+    window.addEventListener('orientationchange', resizeCanvas);
     resizeCanvas();
+    // mobile ads may shift layout after load; re-run once more shortly
+    setTimeout(resizeCanvas, 500);
 
     
 
@@ -1550,8 +1549,8 @@ function showHighScores(hs, autoScroll = false){
   const ct = document.getElementById('gameOverContent');
   let html = `<h2>Top 50</h2>` +
              `<div id="hsBox" style="height:200px;overflow:hidden;display:inline-block;">` +
-             `<ol id="hsList" style="text-align:left;margin:0;padding-left:20px;">`;
-  hs.forEach(i => html += `<li>${i.name} — ${i.score}</li>`);
+             `<ol id="hsList" style="text-align:left;margin:0;padding-left:20px;list-style:none;">`;
+  hs.forEach((i, idx) => html += `<li>${idx + 1}. ${i.name} — ${i.score}</li>`);
   html += `</ol></div><br/><button id="retryBtn">Play Again</button>`;
   ct.innerHTML = html;
   document.getElementById('retryBtn').onclick = () => {


### PR DESCRIPTION
## Summary
- fix duplicate audio element
- improve mobile canvas resizing and handle orientation changes
- ensure leaderboard numbers increment correctly

## Testing
- `node -c /tmp/module.js`

------
https://chatgpt.com/codex/tasks/task_e_684306b2e5948329905b417d0e2c61f1