### PR TITLE
Add persistent coin tracker

### DIFF
--- a/index.html
+++ b/index.html
@@ -414,6 +414,7 @@ let bossObj;                // boss-specific timers & mode
     const rocketPowerR   = 16;
 
     let personalBest = parseInt(localStorage.getItem('birdyBestScore')) || 0;
+    let totalCoins   = parseInt(localStorage.getItem('birdyCoinsEarned')) || 0;
 
     for(let i=0;i<7;i++){
       clouds.push({ x:Math.random()*W, y:20+Math.random()*100, s:0.8+Math.random()*0.4 });
@@ -1423,6 +1424,8 @@ function updateJellies() {
     if (Math.hypot(bird.x - c.x, bird.y - c.y) < bird.rad + coinR) {
       c.taken = true;
       coinCount++;
+      totalCoins++;
+      localStorage.setItem('birdyCoinsEarned', totalCoins);
       playTone(1000, 0.1);//playChord('V', audioCtx.currentTime);
       updateScore();
       runCoins++;
@@ -1799,6 +1802,7 @@ document.addEventListener('keydown', e=>{
           ctx.restore();
         }
 
+        ctx.fillText(`🪙 Coins Earned: ${totalCoins}`, W/2, H - 70);
         ctx.fillText(`Personal Best: ${personalBest}`, W/2, H - 40);
       }
     }


### PR DESCRIPTION
## Summary
- add global `totalCoins` variable with localStorage persistence
- increment persistent coins whenever a coin is collected
- show `Coins Earned` counter on the start screen

## Testing
- `npm test` *(fails: could not find package.json)*
- `htmlhint index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684318734e98832982745a29a6ccde98