### PR TITLE
Update double coin cost

### DIFF
--- a/index.html
+++ b/index.html
@@ -2547,7 +2547,7 @@ function showShop() {
 
     const items = [
       {key:'Revive.png', name:'Revive', cost:25, owned:storedRevives>0, extra:'<small>Continue after falling, max 1 per run</small>'},
-      {key:'Double.png', name:'Double Coins', cost:20, owned:storedDoubles>0, extra:'<small>Next run doubles coins</small>'}
+      {key:'Double.png', name:'Double Coins', cost:50, owned:storedDoubles>0, extra:'<small>Next run doubles coins</small>'}
     ];
 
     if(section==='skins'){


### PR DESCRIPTION
## Summary
- adjust Double Coins shop item cost from 20 to 50

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684510fa82448329b53df4a7fb88ab03