### PR TITLE
Enhance shop visuals and upgrade layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,15 +31,16 @@
       position:absolute; bottom:10px; left:10px;
       color:#fff; font:1rem sans-serif;
       text-shadow:2px 2px 4px #000;
-      z-index:10;
+      z-index:25;                     /* above overlay */
       display:flex; align-items:center;
     }
     #overlay {
-      display:none; position:absolute; top:0; left:0;
-      width:100%; height:100%;
+      display:none; position:absolute; left:0;
+      top:100px; bottom:80px;           /* leave score and coins visible */
+      width:100%;
       background:rgba(0,0,0,0.7);
       color:#fff; font:18px sans-serif;
-      text-align:center; padding-top:80px;
+      text-align:center; padding-top:20px;
       z-index:20;
       overflow-y:auto;            /* allow tall content like story log to scroll */
       padding-bottom:40px;        /* space below last entry */
@@ -98,6 +99,14 @@
       50%{opacity:0.3}
     }
     .flash { animation: flash 1s infinite; }
+
+    @keyframes bounce {
+      0%,100% { transform: translateY(0); }
+      50% { transform: translateY(-6px); }
+    }
+    .iconBounce { animation: bounce 1s infinite; display:inline-block; }
+    .iconWrap { position:relative; display:inline-block; width:32px; height:32px; margin-right:6px; }
+    .iconWrap .shadow { position:absolute; bottom:0; left:50%; width:26px; height:5px; background:rgba(0,0,0,0.3); border-radius:50%; transform:translateX(-50%); }
 
   </style>
 
@@ -2697,8 +2706,8 @@ function showShop() {
 
     if(section==='skins'){
       skins.forEach(s => {
-        html += `<div style="margin:6px;">` +
-                `<img src="assets/${s.key}" width="32" height="32" style="vertical-align:middle;margin-right:6px;">` +
+        html += `<div style="margin:6px;display:flex;align-items:center;">` +
+                `<span class="iconWrap"><img src="assets/${s.key}" width="32" height="32" class="iconBounce"><span class="shadow"></span></span>` +
                 `${s.name} `;
         if (s.owned || s.cost === 0) {
           if (defaultSkin === s.key) {
@@ -2715,8 +2724,8 @@ function showShop() {
       });
     } else if(section==='items') {
       items.forEach(it => {
-        html += `<div style="margin:6px;">`+
-                `<img src="assets/${it.key}" width="32" height="32" style="vertical-align:middle;margin-right:6px;">`+
+        html += `<div style="margin:6px;display:flex;align-items:center;">`+
+                `<span class="iconWrap"><img src="assets/${it.key}" width="32" height="32" class="iconBounce"><span class="shadow"></span></span>`+
                 `${it.name} ${it.extra||''} `;
         if(it.owned){
           html += `(Owned)`;
@@ -2726,8 +2735,8 @@ function showShop() {
         html += `</div>`;
       });
     } else if(section==='upgrades') {
-      html += `<div id="upgradeTreeWrap" style="text-align:center;">`+
-              `<svg id="upgradeTreeSVG" width="600" height="600"></svg>`+
+      html += `<div id="upgradeTreeWrap" style="text-align:center;width:100%;height:100%;display:flex;justify-content:center;align-items:center;">`+
+              `<svg id="upgradeTreeSVG" style="width:100%;height:100%;max-width:600px;max-height:600px;"></svg>`+
               `</div>`;
     }
 
@@ -2804,8 +2813,12 @@ function renderUpgradeTree() {
   const svg = document.getElementById('upgradeTreeSVG');
   while (svg.firstChild) svg.removeChild(svg.firstChild);
 
-  const cx = 300, cy = 300;
-  const radius = 200;
+  const rect = svg.getBoundingClientRect();
+  const w = rect.width;
+  const h = rect.height;
+  const cx = w/2;
+  const cy = h/2;
+  const radius = Math.min(w,h)/2 - 40;
   const branchCount = upgradeTreeConfig.length;
   upgradeTreeConfig.forEach((branch, bIndex) => {
     const angle = (Math.PI*2/branchCount)*bIndex - Math.PI/2;
@@ -2846,6 +2859,17 @@ function renderUpgradeTree() {
       txt.setAttribute('font-size','10');
       txt.textContent = owned ? '✓' : cost;
       svg.appendChild(txt);
+
+      if(upg.id.includes('coin') || upg.id.includes('rocket')){
+        const icon = document.createElementNS(svg.namespaceURI,'text');
+        icon.setAttribute('x', nx);
+        icon.setAttribute('y', ny - 30);
+        icon.setAttribute('text-anchor','middle');
+        icon.setAttribute('font-size','16');
+        icon.setAttribute('class','iconBounce');
+        icon.textContent = upg.id.includes('coin') ? '🪙' : '🚀';
+        svg.appendChild(icon);
+      }
 
       circ.addEventListener('mouseenter', e => {
         showTooltip(upg.name+': '+upg.description);


### PR DESCRIPTION
## Summary
- keep coin/score display visible while browsing the shop
- animate shop icons with a bounce and shadow
- make upgrade tree responsive and display bouncing icons for coin/rocket upgrades

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68476814194c8329a62fc27a54971946