### PR TITLE
Improve upgrade tree display and stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -2317,6 +2317,25 @@ function updateReviveDisplay(){
   document.getElementById('reviveCount').textContent = `${storedRevives}/1`;
 }
 
+function updateUpgradeStats(){
+  const el = document.getElementById('upgradeStats');
+  if(!el) return;
+  const rate = (baseCoinProb * coinSpawnMult * 100).toFixed(0);
+  let html = `Coin Rate: ${rate}%`;
+  const rocketNames = [];
+  upgradeTreeConfig.forEach(b=>{
+    b.upgrades.forEach(u=>{
+      if(purchasedUpgrades.includes(u.id) && u.id.includes('rocket')){
+        rocketNames.push(u.name);
+      }
+    });
+  });
+  if(rocketNames.length){
+    html += `<div>Rocket Upgrades: ${rocketNames.join(', ')}</div>`;
+  }
+  el.innerHTML = html;
+}
+
 function startReviveEffect(){
   usedRevive = true;
   reviveTimer = 180;         // 3 second countdown
@@ -2739,12 +2758,16 @@ function showShop() {
     } else if(section==='upgrades') {
       html += `<div id="upgradeTreeWrap" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:100%;height:100%;display:flex;justify-content:center;align-items:center;">`+
               `<svg id="upgradeTreeSVG" style="width:100%;height:100%;max-width:600px;max-height:600px;"></svg>`+
+              `<div id="upgradeStats" style="position:absolute;bottom:0;left:50%;transform:translateX(-50%);text-align:center;font-size:14px;"></div>`+
               `</div>`;
     }
 
     html += `</div><button id="shopClose">Close</button>`;
     ct.innerHTML = html;
-    if(section==='upgrades') renderUpgradeTree();
+    if(section==='upgrades') {
+      renderUpgradeTree();
+      updateUpgradeStats();
+    }
 
     ct.querySelectorAll('#tabSkins').forEach(b=>b.onclick=()=>{section='skins';render();});
     ct.querySelectorAll('#tabItems').forEach(b=>b.onclick=()=>{section='items';render();});
@@ -2822,8 +2845,10 @@ function renderUpgradeTree() {
   const cy = h/2;
   const radius = Math.min(w,h)/2 - 40;
   const branchCount = upgradeTreeConfig.length;
+  const branchSpacing = Math.PI / 3; // 60° between branches
+  const startAngle = -branchSpacing * (branchCount - 1) / 2;
   upgradeTreeConfig.forEach((branch, bIndex) => {
-    const angle = (Math.PI*2/branchCount)*bIndex;
+    const angle = startAngle + branchSpacing * bIndex;
     const line = document.createElementNS(svg.namespaceURI,'line');
     const lx = cx + Math.cos(angle)*radius;
     const ly = cy + Math.sin(angle)*radius;
@@ -2886,6 +2911,7 @@ function renderUpgradeTree() {
           purchasedUpgrades.push(upg.id);
           localStorage.setItem('purchasedUpgrades', JSON.stringify(purchasedUpgrades));
           renderUpgradeTree();
+          updateUpgradeStats();
         } else {
           showTooltip('Need '+cost+' coins');
         }


### PR DESCRIPTION
## Summary
- tighten angle between upgrade tree branches
- show coin rate and rocket upgrades under the skill tree
- keep upgrade stats updated whenever upgrades change

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68476f88b18c8329987fda1c83152d06