### PR TITLE
Fix skill tree overlay and coin rate display

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
       display:none; position:absolute; left:0;
       top:100px; bottom:80px;           /* leave score and coins visible */
       width:100%;
-      background:rgba(0,0,0,0.7);
+      background:rgba(0,0,0,0.5);
       color:#fff; font:18px sans-serif;
       text-align:center; padding-top:20px;
       z-index:20;
@@ -677,7 +677,7 @@ const moneyLeaves = [];
     let doublePulse   = 0;
 
     // ── Upgrade state ──
-    let coinSpawnMult    = 1;
+    let coinSpawnBonus   = 0;
     let rocketSizeMult   = 1;
     let rocketDamageMult = 1;
     let rocketFlameEnabled = false;
@@ -694,7 +694,7 @@ const moneyLeaves = [];
             id: 'natural_coin10',
             name: '+10% Coin Spawn',
             description: 'Increase coin spawn rate by 10%',
-            effect: () => { coinSpawnMult *= 1.10; },
+            effect: () => { coinSpawnBonus += 0.10; },
             costFactor: 1
           }
         ]
@@ -1482,7 +1482,7 @@ function spawnPipe(){
   const decay = Math.pow(0.9, Math.floor(pipeCount/10)),
         appP  = baseAppleProb /* * decay*/,
         rocketP = baseTripleProb;
-  let coinP = baseCoinProb * (marathonMode ? 0.5 : 1) * coinSpawnMult;
+  let coinP = (baseCoinProb + coinSpawnBonus) * (marathonMode ? 0.5 : 1);
   if (defaultSkin === 'MoneySkin.png') coinP *= 1.2;
 
   // pick a random gap in the top half
@@ -2320,7 +2320,7 @@ function updateReviveDisplay(){
 function updateUpgradeStats(){
   const el = document.getElementById('upgradeStats');
   if(!el) return;
-  const rate = (baseCoinProb * coinSpawnMult * 100).toFixed(0);
+  const rate = ((baseCoinProb + coinSpawnBonus) * 100).toFixed(0);
   let html = `Coin Rate: ${rate}%`;
   const rocketNames = [];
   upgradeTreeConfig.forEach(b=>{
@@ -2334,6 +2334,18 @@ function updateUpgradeStats(){
     html += `<div>Rocket Upgrades: ${rocketNames.join(', ')}</div>`;
   }
   el.innerHTML = html;
+  const coinEl = document.getElementById('coinCount');
+  if(coinEl){
+    const rect = coinEl.getBoundingClientRect();
+    el.style.left = (rect.left + rect.width/2) + 'px';
+    el.style.top = (rect.top - el.offsetHeight - 4) + 'px';
+    el.style.transform = 'translateX(-50%)';
+  } else {
+    el.style.left = '50%';
+    el.style.top = '';
+    el.style.bottom = '0';
+    el.style.transform = 'translateX(-50%)';
+  }
 }
 
 function startReviveEffect(){
@@ -2704,7 +2716,7 @@ function showShop() {
 
   function render() {
     let html = `<h2>Shop</h2>` +
-               `<p>Coins: ${totalCoins}</p>` +
+               `<p id="coinCount">Coins: ${totalCoins}</p>` +
                `<div style="margin-bottom:10px;">`+
                `<button id="tabSkins" ${section==='skins'?'disabled':''}>Skins</button>`+
                `<button id="tabItems" ${section==='items'?'disabled':''}>Items</button>`+
@@ -2756,9 +2768,9 @@ function showShop() {
         html += `</div>`;
       });
     } else if(section==='upgrades') {
-      html += `<div id="upgradeTreeWrap" style="position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:100%;height:100%;display:flex;justify-content:center;align-items:center;">`+
+      html += `<div id="upgradeTreeWrap" style="position:relative;margin-top:10px;width:100%;height:calc(100% - 60px);display:flex;justify-content:center;align-items:center;">`+
               `<svg id="upgradeTreeSVG" style="width:100%;height:100%;max-width:600px;max-height:600px;"></svg>`+
-              `<div id="upgradeStats" style="position:absolute;bottom:0;left:50%;transform:translateX(-50%);text-align:center;font-size:14px;"></div>`+
+              `<div id="upgradeStats" style="position:absolute;text-align:center;font-size:14px;"></div>`+
               `</div>`;
     }
 


### PR DESCRIPTION
## Summary
- lighten overlay background
- ensure skill tree overlay does not block close buttons
- show coin rate above coin count and recalc additively
- adjust coin upgrade to add +10% instead of multiply

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684771e4cad483299faf5e00e12f0b74