### PR TITLE
Add themed columns for skins

### DIFF
--- a/index.html
+++ b/index.html
@@ -524,6 +524,12 @@ const cowRocketSprite = new Image();
 cowRocketSprite.src   = 'assets/cow_rocket.png';
 const cowPipeImg      = new Image();
 cowPipeImg.src        = 'assets/cow_pipe.png';
+const iceColumnImg    = new Image();
+iceColumnImg.src      = 'assets/ice_column.png';
+const fireColumnImg   = new Image();
+fireColumnImg.src     = 'assets/fire_column.png';
+const storyColumnImg  = new Image();
+storyColumnImg.src    = 'assets/story_column.png';
 const cowUpSprite     = new Image();
 cowUpSprite.src       = 'assets/cow_up.png';
 const cowDownSprite   = new Image();
@@ -696,6 +702,8 @@ const rocketParticles = [];
 const rocketSmoke = [];
 const rocketFlames = [];
 const rocketSnow = [];
+const columnFlames = [];
+const columnSnow = [];
 const skinParticles = [];
 const moneyLeaves = [];
 const milkParticles = [];
@@ -827,6 +835,14 @@ const milkParticles = [];
     function rgbToHex(r,g,b){ return '#' + [r,g,b].map(x=>Math.round(x).toString(16).padStart(2,'0')).join(''); }
     function lerpColor(a,b,t){ const ca=hexToRgb(a), cb=hexToRgb(b); return rgbToHex(ca.r+(cb.r-ca.r)*t, ca.g+(cb.g-ca.g)*t, ca.b+(cb.b-ca.b)*t); }
     function shade(col,amt){ if(col[0]==='#') col=col.slice(1); const num=parseInt(col,16), r=(num>>16)+amt, g=((num>>8)&255)+amt, b=(num&255)+amt; const rr=Math.max(0,Math.min(255,r)), gg=Math.max(0,Math.min(255,g)), bb=Math.max(0,Math.min(255,b)); return '#'+((rr<<16)|(gg<<8)|bb).toString(16).padStart(6,'0'); }
+
+    function isFireSkin(){
+      return defaultSkin === 'FireSkinBase.png' || birdSprite.src.includes('FireSkinMech');
+    }
+
+    function isAquaSkin(){
+      return defaultSkin === 'AquaSkinBase.png' || birdSprite.src.includes('AquaSkinMech');
+    }
 
     function isStorySkin(){
       return defaultSkin === 'story_bird.png' || birdSprite.src.includes('Story_mech');
@@ -1723,6 +1739,18 @@ function spawnPipe(){
     phase: Math.random() * Math.PI * 2,
     amp: pipeMoveAmplitude
   });
+  const p = pipes[pipes.length - 1];
+  if (isFireSkin()) {
+    p.img = fireColumnImg;
+    p.fireFX = Math.random() < 0.3;
+  } else if (isAquaSkin()) {
+    p.img = iceColumnImg;
+    p.snowFX = true;
+  } else if (isStorySkin()) {
+    p.img = storyColumnImg;
+  } else if (defaultSkin === 'cow_down.png' || birdSprite.src.includes('cow_mech')) {
+    p.img = cowPipeImg;
+  }
 
   // — apples —
   if (Math.random() < appP) {
@@ -1988,6 +2016,39 @@ function updateMoneyLeaves(){
   }
 }
 
+function updateColumnFlames(){
+  for(let i=columnFlames.length-1;i>=0;i--){
+    const f = columnFlames[i];
+    f.life--;
+    ctx.save();
+    ctx.globalAlpha = f.life / 15;
+    ctx.fillStyle = 'orange';
+    ctx.beginPath();
+    ctx.arc(f.x + (Math.random()-0.5)*6, f.y + (Math.random()-0.5)*20, 3, 0, Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+    if(f.life<=0) columnFlames.splice(i,1);
+  }
+}
+
+function updateColumnSnow(){
+  for(let i=columnSnow.length-1;i>=0;i--){
+    const s = columnSnow[i];
+    s.life--;
+    s.x += s.vx;
+    s.y += s.vy;
+    s.vy += 0.02;
+    ctx.save();
+    ctx.globalAlpha = s.life / 20;
+    ctx.fillStyle = '#fff';
+    ctx.beginPath();
+    ctx.arc(s.x, s.y, 2, 0, Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+    if(s.life<=0) columnSnow.splice(i,1);
+  }
+}
+
 function updateReviveEffect() {
   if (reviveTimer <= 0) return;
   if (frames % 15 === 0) {
@@ -2059,31 +2120,38 @@ function updateReviveEffect() {
 
     function drawPipes(){
       pipes.forEach(p=>{
-        const useCow = defaultSkin === 'cow_down.png' || birdSprite.src.includes('cow_mech');
-        if (useCow) {
-          ctx.drawImage(cowPipeImg, p.x, 0, pipeW, p.top);
+        const img = p.img;
+        if (img) {
+          ctx.drawImage(img, p.x, 0, pipeW, p.top);
           ctx.save();
           ctx.translate(p.x, p.top + p.gap);
           ctx.scale(1, -1);
-          ctx.drawImage(cowPipeImg, 0, - (H - p.top - p.gap), pipeW, H - p.top - p.gap);
+          ctx.drawImage(img, 0, -(H - p.top - p.gap), pipeW, H - p.top - p.gap);
           ctx.restore();
         } else {
-          ctx.fillStyle=p.fireGlow ? '#FF5722' : p.color;
-          ctx.fillRect(p.x,0,pipeW,p.top);
-          ctx.fillRect(p.x,p.top+p.gap,pipeW,H-p.top-p.gap);
+          ctx.fillStyle = p.fireGlow ? '#FF5722' : p.color;
+          ctx.fillRect(p.x, 0, pipeW, p.top);
+          ctx.fillRect(p.x, p.top + p.gap, pipeW, H - p.top - p.gap);
         }
-        if(!useCow && p.fireGlow){
+        if (!img && p.fireGlow) {
           ctx.save();
-          ctx.fillStyle='rgba(255,80,0,0.6)';
-          ctx.shadowColor='rgba(255,80,0,0.8)';
-          ctx.shadowBlur=15;
-          ctx.fillRect(p.x-2,p.top-8,pipeW+4,8);
-          ctx.fillRect(p.x-2,p.top+p.gap,pipeW+4,8);
+          ctx.fillStyle = 'rgba(255,80,0,0.6)';
+          ctx.shadowColor = 'rgba(255,80,0,0.8)';
+          ctx.shadowBlur = 15;
+          ctx.fillRect(p.x-2, p.top-8, pipeW+4, 8);
+          ctx.fillRect(p.x-2, p.top+p.gap, pipeW+4, 8);
           ctx.restore();
-        }else if(!useCow){
-          ctx.fillStyle=shade(p.color,-20);
-          ctx.fillRect(p.x-2,p.top-8,pipeW+4,8);
-          ctx.fillRect(p.x-2,p.top+p.gap,pipeW+4,8);
+        } else if (!img) {
+          ctx.fillStyle = shade(p.color,-20);
+          ctx.fillRect(p.x-2, p.top-8, pipeW+4, 8);
+          ctx.fillRect(p.x-2, p.top+p.gap, pipeW+4, 8);
+        }
+
+        if (p.fireFX && frames % 5 === 0) {
+          columnFlames.push({x:p.x + pipeW/2, y:p.top + p.gap/2, life:15});
+        }
+        if (p.snowFX && frames % 10 === 0) {
+          columnSnow.push({x:p.x + Math.random()*pipeW, y:p.top + Math.random()*p.gap, vx:(Math.random()-0.5)*0.3, vy:0, life:20});
         }
       });
     }
@@ -2955,6 +3023,8 @@ function handleHit(){
   rocketSmoke.length = 0;
   rocketFlames.length = 0;
   rocketSnow.length = 0;
+  columnFlames.length = 0;
+  columnSnow.length = 0;
   rocketPowerups.length = 0;
   slicingDisks.length = 0;
   
@@ -3621,6 +3691,8 @@ if (state === STATE.BossExplode) {
   updateImpactParticles();
   updateMilkParticles();
   updateSkinParticles();
+  updateColumnFlames();
+  updateColumnSnow();
   updateMoneyLeaves();
   bird.draw();
   if (--bossExplosionTimer <= 0) state = STATE.Play;
@@ -3709,6 +3781,8 @@ if (state === STATE.MechaTransit) {
   applyShake();
   drawBackground();
   updateSkinParticles();
+  updateColumnFlames();
+  updateColumnSnow();
   updateMoneyLeaves();
   // ── draw & animate any flying armor pieces ──
 for (let j = flyingArmor.length - 1; j >= 0; j--) {
@@ -3730,6 +3804,8 @@ applyShake();
 
 drawBackground();
  updateSkinParticles();
+ updateColumnFlames();
+ updateColumnSnow();
  updateMoneyLeaves();
 for (let j = flyingArmor.length - 1; j >= 0; j--) {
   const a = flyingArmor[j];


### PR DESCRIPTION
## Summary
- add column images for fire, aqua, story and use in `spawnPipe`
- implement helper skin-check functions
- render custom column sprites in `drawPipes`
- add optional fire/snow particle effects
- reset and update new effects during gameplay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a34f8b9808329ab5a65392ee1058d