### PR TITLE
Fix story skin pipe visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -1746,8 +1746,9 @@ function spawnPipe(){
   } else if (isAquaSkin()) {
     p.img = iceColumnImg;
     p.snowFX = true;
+  // keep normal pipes for the Story skin
   } else if (isStorySkin()) {
-    p.img = storyColumnImg;
+    // no custom column image
   } else if (defaultSkin === 'cow_down.png' || birdSprite.src.includes('cow_mech')) {
     p.img = cowPipeImg;
   }


### PR DESCRIPTION
## Summary
- use default pipe graphics when the Story skin is equipped

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684a3a3faa1c8329bc7bc8205ec5f997