### PR TITLE
Add scribbled drifting pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -1970,6 +1970,9 @@ function updateSkinParticles() {
     p.x += p.vx;
     p.y += p.vy;
     if (p.type === 'page') {
+      if (p.floatPhase === undefined) p.floatPhase = Math.random() * Math.PI * 2;
+      p.floatPhase += 0.05;
+      p.x += Math.sin(p.floatPhase) * 0.3;
       p.vx *= 0.98;
       p.vy *= 0.98;
       p.vy += 0.05;
@@ -1994,6 +1997,24 @@ function updateSkinParticles() {
       ctx.lineTo(-p.size, p.size);
       ctx.quadraticCurveTo(-p.size * 1.2, 0, -p.size, -p.size);
       ctx.fill();
+      ctx.strokeStyle = '#bbb';
+      ctx.lineWidth = 1;
+      if (!p.lines) {
+        p.lines = [];
+        const n = 2 + Math.floor(Math.random() * 2);
+        for (let j = 0; j < n; j++) {
+          p.lines.push({
+            y: -p.size * 0.6 + j * p.size * 0.6,
+            o: (Math.random() - 0.5) * p.size * 0.3
+          });
+        }
+      }
+      for (const l of p.lines) {
+        ctx.beginPath();
+        ctx.moveTo(-p.size * 0.7, l.y);
+        ctx.lineTo(p.size * 0.7, l.y + l.o);
+        ctx.stroke();
+      }
     } else if (p.type === 'fire') {
       const g = ctx.createRadialGradient(p.x, p.y, 0, p.x, p.y, p.size);
       g.addColorStop(0, 'rgba(255,255,0,0.5)');


### PR DESCRIPTION
## Summary
- make story skin page particles drift side to side
- add scribble lines to pages so they look written

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684a555fa5348329b607ecd893bed6c9