### PR TITLE
Improve upgrade system and cow theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,7 @@
     const ownedSkins = JSON.parse(localStorage.getItem('birdyOwnedSkins')||'{}');
     let defaultSkin = localStorage.getItem('birdySkin') || 'birdieV2.png';
     birdSprite.src = 'assets/' + defaultSkin;
+    updateBgMusicSrc();
     // → New “mecha” states
 const mechaStages = [
   'assets/stage1.png',
@@ -580,6 +581,9 @@ const tossBombs   = [];   // upward‐toss bombs
 function playChord(/* chordType, startTime */) {}
 const bgMusic = document.getElementById('bgMusic');
 bgMusic.volume = 0.5;
+function updateBgMusicSrc(){
+  bgMusic.src = defaultSkin === 'cow_down.png' ? 'assets/cow_theme.mp3' : 'assets/dream.guitar.mp3';
+}
 
 // simple WebAudioContext for playTone()
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
@@ -683,6 +687,7 @@ const rocketParticles = [];
 const rocketSmoke = [];
 const rocketFlames = [];
 const rocketSnow = [];
+const splashParticles = [];
 const columnFlames = [];
 const columnSnow = [];
 const skinParticles = [];
@@ -745,6 +750,20 @@ const milkParticles = [];
             costFactor: 1
           },
           {
+            id: 'natural_coin20',
+            name: '+10% More',
+            description: 'Coins appear 10% more often',
+            effect: () => { coinSpawnBonus += 0.10; },
+            costFactor: 1.1
+          },
+          {
+            id: 'natural_extra_slots',
+            name: 'Equip +2 Abilities',
+            description: 'Allows two additional active upgrades',
+            effect: () => { upgradeSlots += 2; localStorage.setItem('upgradeSlots', upgradeSlots); },
+            costFactor: 1.3
+          },
+          {
             id: 'natural_magnet',
             name: '🧲 Magnetism',
             description: 'Coins are drawn to you',
@@ -776,19 +795,34 @@ const milkParticles = [];
             description: 'Rockets cause splash damage',
             effect: () => { rocketSplash = true; },
             costFactor: 1.3
+          },
+          {
+            id: 'mech_rocket_pulse',
+            name: 'Pulse Rockets',
+            description: 'Rockets emit damaging pulses',
+            effect: () => { rocketPulse = true; },
+            costFactor: 1.4
           }
         ]
       }
     ];
 
-    function applyPurchasedUpgrades() {
-      upgradeTreeConfig.forEach(branch => {
-        branch.upgrades.forEach(upg => {
-          if (purchasedUpgrades.includes(upg.id)) upg.effect();
+    function applyActiveUpgrades() {
+      coinSpawnBonus   = 0;
+      rocketSizeMult   = 1;
+      rocketDamageMult = 1;
+      rocketFlameEnabled = false;
+      rocketSplash     = false;
+      rocketPulse      = false;
+      magnetActive     = false;
+      activeUpgrades.forEach(id => {
+        upgradeTreeConfig.forEach(b => {
+          const u = b.upgrades.find(x => x.id === id);
+          if (u) u.effect();
         });
       });
     }
-    applyPurchasedUpgrades();
+    applyActiveUpgrades();
     updateReviveDisplay();
 
     // tooltip element for upgrade tree
@@ -943,6 +977,7 @@ pipes.length     = apples.length = coins.length = 0;
       if(frames % 4 === 0){
         spawnImpactParticles(p.x + (Math.random()-0.5)*p.r, p.y + (Math.random()-0.5)*p.r, 0,0);
         p.smoke.push({ x:p.x + (Math.random()-0.5)*p.r, y:p.y + (Math.random()-0.5)*p.r, alpha:1, r:4 });
+        electricRings.push({ x:p.x, y:p.y, r:30, alpha:0.6, color:'cyan' });
       }
       triggerShake(1);
       return;
@@ -1173,7 +1208,9 @@ if (p.strongQueue > 0) {
           p.isCharging = true;
           triggerShake(2);
           spawnImpactParticles(p.x, p.y, 0, 0);
-          p.smoke.push({ x:p.x, y:p.y, alpha:1, r:4 });
+          for(let i=0;i<3;i++) p.smoke.push({ x:p.x + (Math.random()-0.5)*p.r, y:p.y + (Math.random()-0.5)*p.r, alpha:1, r:4 });
+          electricRings.push({ x:p.x, y:p.y, r:30, alpha:0.6, color:'cyan' });
+          electricRings.push({ x:p.x, y:p.y, r:30, alpha:0.6, color:'magenta' });
           if(Math.random() < 0.5) coins.push({x:p.x,y:p.y,taken:false,homing:true});
           else rocketPowerups.push({x:p.x,y:p.y,taken:false,homing:true});
         }
@@ -1699,6 +1736,7 @@ if (inMecha) {
       tripleElectric = false;
       electricTimer = 0;
       birdSprite.src = 'assets/' + defaultSkin;
+      updateBgMusicSrc();
     }
   }
   // if not armored, die as normal
@@ -1839,16 +1877,19 @@ function spawnExplosion(x, y, fromRocket = false, electric = false) {
   if (fromRocket && rocketSplash) {
     for(let a=0;a<8;a++){
       const ang = a * Math.PI/4;
-      slicingDisks.push({ x, y, vx: Math.cos(ang)*3, vy: Math.sin(ang)*3, rot:0, hp:1, enemy:false });
+      slicingDisks.push({ x, y, vx: Math.cos(ang)*3, vy: Math.sin(ang)*3, rot:0, hp:1, enemy:false, electric });
+    }
+    for(let i=0;i<12;i++){
+      splashParticles.push({x,y, vx:(Math.random()-0.5)*3, vy:(Math.random()-0.5)*3, life:20});
     }
   }
   if (electric) {
     triggerShake(8);
-    electricRings.push({ x, y, r: 20, alpha: 0.6, color: 'cyan' });
-    electricRings.push({ x, y, r: 20, alpha: 0.6, color: 'magenta' });
+    electricRings.push({ x, y, r: 30, alpha: 0.6, color: 'cyan' });
+    electricRings.push({ x, y, r: 30, alpha: 0.6, color: 'magenta' });
     for(let jj=jellies.length-1;jj>=0;jj--){
       const j=jellies[jj];
-      if(Math.hypot(j.x-x,j.y-y)<40){
+      if(Math.hypot(j.x-x,j.y-y)<60){
         spawnImpactParticles(j.x, j.y, j.x - x, j.y - y);
         const mag=Math.hypot(j.x - x, j.y - y)||1;
         j.pushX += (j.x - x)/mag * 6;
@@ -1942,6 +1983,23 @@ function updateMilkParticles() {
     ctx.fill();
     ctx.restore();
     if (m.life <= 0) milkParticles.splice(i,1);
+  }
+}
+
+function updateSplashParticles() {
+  for (let i = splashParticles.length - 1; i >= 0; i--) {
+    const p = splashParticles[i];
+    p.x += p.vx;
+    p.y += p.vy;
+    p.life--;
+    ctx.save();
+    ctx.globalAlpha = p.life / 20;
+    ctx.fillStyle = 'orange';
+    ctx.beginPath();
+    ctx.arc(p.x, p.y, 3, 0, Math.PI*2);
+    ctx.fill();
+    ctx.restore();
+    if (p.life <= 0) splashParticles.splice(i,1);
   }
 }
 
@@ -2498,6 +2556,7 @@ for (let i = stage2Bombs.length - 1; i >= 0; i--) {
           mechaTriggered = false;
           mechSpeed = baseSpeed;
           birdSprite.src = 'assets/' + defaultSkin;
+          updateBgMusicSrc();
           mechaMusic.pause();
           bgMusic.currentTime = 0;
           bgMusic.play().catch(()=>{});
@@ -2570,6 +2629,7 @@ for (let i = stage2Bombs.length - 1; i >= 0; i--) {
   updateExplosions();
   updateImpactParticles();
   updateMilkParticles();
+  updateSplashParticles();
 }
 
 function updateJellies() {
@@ -2678,8 +2738,8 @@ function updateSliceDisks() {
       for(let jj=jellies.length-1;jj>=0;jj--){
         const j=jellies[jj];
         if(Math.hypot(d.x-j.x,d.y-j.y)<24){
-          spawnExplosion(j.x,j.y);
-          j.hp=(j.hp||1)-1;
+          spawnExplosion(j.x,j.y,false,d.electric);
+          j.hp=(j.hp||1)-(d.damageMult||1);
           j.flashTimer=6;
           if(j.hp<=0){ jellies.splice(jj,1); runJellies++; if(runJellies>=5) unlockAchievement('kill5'); }
           d.hp=0;
@@ -2691,8 +2751,8 @@ function updateSliceDisks() {
         if(rin.isBossShot) continue;
         if(Math.hypot(d.x-rin.x,d.y-rin.y)<24){
           rocketsIn.splice(k,1);
-          spawnExplosion(d.x,d.y);
-          score++; updateScore();
+          spawnExplosion(d.x,d.y,false,d.electric);
+          score += d.damageMult||1; updateScore();
           d.hp=0;
           break;
         }
@@ -2898,6 +2958,11 @@ function updateSliceDisks() {
         if(tripleShot){
           tripleElectric = true;
           electricTimer = 540;
+          if(rocketPulse){
+            for(let n=-1;n<=1;n++){
+              slicingDisks.push({ x: bird.x, y: bird.y, vx:6, vy:n*3, rot:0, hp:1, enemy:false, electric:true, damageMult:2 });
+            }
+          }
         }
         tripleShot = true;
         runPowerups++;
@@ -2983,7 +3048,7 @@ function updateUpgradeStats(){
   const rocketNames = [];
   upgradeTreeConfig.forEach(b=>{
     b.upgrades.forEach(u=>{
-      if(purchasedUpgrades.includes(u.id) && u.id.includes('rocket')){
+      if(activeUpgrades.includes(u.id) && u.id.includes('rocket')){
         rocketNames.push(u.name);
       }
     });
@@ -2991,6 +3056,7 @@ function updateUpgradeStats(){
   if(rocketNames.length){
     html += `<div>Rocket Upgrades: ${rocketNames.join(', ')}</div>`;
   }
+  html += `<div>Slots: ${activeUpgrades.length}/${upgradeSlots}</div>`;
   if(magnetActive){
     html += `<div>Magnetism On</div>`;
   }
@@ -3474,6 +3540,7 @@ function showShop() {
           defaultSkin = key;
           localStorage.setItem('birdySkin', defaultSkin);
           birdSprite.src = 'assets/' + defaultSkin;
+          updateBgMusicSrc();
           trackEvent('shop_skin_purchased', { skin: key });
           render();
         }
@@ -3507,6 +3574,7 @@ function showShop() {
         defaultSkin = key;
         localStorage.setItem('birdySkin', defaultSkin);
         birdSprite.src = 'assets/' + defaultSkin;
+        updateBgMusicSrc();
         render();
       };
     });
@@ -3555,15 +3623,16 @@ function renderUpgradeTree() {
       const ny = cy + Math.sin(angle)*r;
       const cost = branch.costBase * Math.pow(upg.costFactor, idx);
       const owned = purchasedUpgrades.includes(upg.id);
+      const equipped = activeUpgrades.includes(upg.id);
 
       const circ = document.createElementNS(svg.namespaceURI,'circle');
       circ.setAttribute('cx',nx);
       circ.setAttribute('cy',ny);
       circ.setAttribute('r',20);
-      circ.setAttribute('fill', owned ? branch.color : '#333');
+      circ.setAttribute('fill', owned ? (equipped ? branch.color : '#555') : '#333');
       circ.setAttribute('stroke',branch.color);
       circ.setAttribute('stroke-width','2');
-      circ.style.cursor = owned ? 'default' : 'pointer';
+      circ.style.cursor = 'pointer';
       svg.appendChild(circ);
 
       const txt = document.createElementNS(svg.namespaceURI,'text');
@@ -3572,7 +3641,7 @@ function renderUpgradeTree() {
       txt.setAttribute('text-anchor','middle');
       txt.setAttribute('fill','#fff');
       txt.setAttribute('font-size','10');
-      txt.textContent = owned ? '✓' : cost;
+      txt.textContent = owned ? (equipped ? '✓' : 'P') : cost;
       svg.appendChild(txt);
 
       if(upg.id.includes('coin') || upg.id.includes('rocket') || upg.id.includes('magnet')){
@@ -3591,17 +3660,32 @@ function renderUpgradeTree() {
       });
       circ.addEventListener('mouseleave', hideTooltip);
       circ.addEventListener('click', () => {
-        if (owned) return;
-        if (purchasedUpgrades.length >= 2) {
-          showTooltip('Only two upgrades allowed');
+        if (owned) {
+          const idx = activeUpgrades.indexOf(upg.id);
+          if (idx >= 0) {
+            activeUpgrades.splice(idx,1);
+          } else if (activeUpgrades.length < upgradeSlots) {
+            activeUpgrades.push(upg.id);
+          } else {
+            showTooltip('Max equipped');
+            return;
+          }
+          localStorage.setItem('activeUpgrades', JSON.stringify(activeUpgrades));
+          applyActiveUpgrades();
+          updateUpgradeStats();
+          renderUpgradeTree();
           return;
         }
         if (totalCoins >= cost) {
           totalCoins -= cost;
           localStorage.setItem('birdyCoinsEarned', totalCoins);
-          upg.effect();
           purchasedUpgrades.push(upg.id);
           localStorage.setItem('purchasedUpgrades', JSON.stringify(purchasedUpgrades));
+          if (activeUpgrades.length < upgradeSlots) {
+            activeUpgrades.push(upg.id);
+            localStorage.setItem('activeUpgrades', JSON.stringify(activeUpgrades));
+          }
+          applyActiveUpgrades();
           renderUpgradeTree();
           updateUpgradeStats();
         } else {
@@ -3824,6 +3908,7 @@ if (state === STATE.BossExplode) {
   updateExplosions();
   updateImpactParticles();
   updateMilkParticles();
+  updateSplashParticles();
   updateElectricEffect();
   updateSkinParticles();
   updateColumnFlames();


### PR DESCRIPTION
## Summary
- allow equipping/unequipping upgrades
- add extra coin and ability slot upgrades
- add rocket pulse upgrade and improve splash visuals
- change background music when cow skin is equipped
- show new splash particles and stronger electric explosions
- tweak boss stun effects

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684b7e8f170c8329ab3c7f5cce4b18c1