### PR TITLE
Fix bg music init crash

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,12 +133,6 @@
   <!-- ────────────────────────────────── -->
 
   <audio id="bgMusic"
-         src="assets/dream.guitar.mp3"
-         loop
-         preload="metadata"></audio>
-  <!-- …the rest of your code… -->
-
-  <audio id="bgMusic"
        src="assets/dream.guitar.mp3"
        loop
        preload="metadata"></audio>
@@ -242,7 +236,6 @@
     const ownedSkins = JSON.parse(localStorage.getItem('birdyOwnedSkins')||'{}');
     let defaultSkin = localStorage.getItem('birdySkin') || 'birdieV2.png';
     birdSprite.src = 'assets/' + defaultSkin;
-    updateBgMusicSrc();
     // → New “mecha” states
 const mechaStages = [
   'assets/stage1.png',
@@ -584,6 +577,7 @@ bgMusic.volume = 0.5;
 function updateBgMusicSrc(){
   bgMusic.src = defaultSkin === 'cow_down.png' ? 'assets/cow_theme.mp3' : 'assets/dream.guitar.mp3';
 }
+updateBgMusicSrc();
 
 // simple WebAudioContext for playTone()
 const audioCtx = new (window.AudioContext || window.webkitAudioContext)();


### PR DESCRIPTION
## Summary
- remove duplicate background music `<audio>` element
- initialize background music after audio setup

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684b85d2401c83299c9fa79e06dc2353