### PR TITLE
Round upgrade costs to nearest 5

### DIFF
--- a/index.html
+++ b/index.html
@@ -3715,7 +3715,9 @@ function renderUpgradeTree() {
     col.className = "branchCol";
     tree.appendChild(col);
     branch.upgrades.forEach((upg, idx) => {
-      const cost = branch.costBase * Math.pow(upg.costFactor, idx);
+      const cost = Math.round(
+        (branch.costBase * Math.pow(upg.costFactor, idx)) / 5
+      ) * 5;
       const owned = ownedUpgrades.includes(upg.id);
       const equipped = equippedUpgrades.includes(upg.id);
       const node = document.createElement("div");


### PR DESCRIPTION
## Summary
- round upgrade tree cost calculations to nearest 5 coins

## Testing
- `grep -n Math.round -n index.html | head`

------
https://chatgpt.com/codex/tasks/task_e_684c63d878b08329a3b67666f35ee7bb