### PR TITLE
Fix legacy upgrade mapping for pulse rockets

### DIFF
--- a/index.html
+++ b/index.html
@@ -741,7 +741,12 @@ const staggerSparks = [];
     if(!ownedUpgrades.length){
       const legacy = JSON.parse(localStorage.getItem('purchasedUpgrades') || '[]');
       if(legacy.length){
-        ownedUpgrades = legacy;
+        // legacy data used numeric indices; map them to new upgrade IDs
+        const idMap = [
+          'natural_coin10', 'natural_coin20', 'natural_slots', 'natural_magnet',
+          'mech_rocket_big', 'mech_rocket_splash', 'mech_rocket_pulse'
+        ];
+        ownedUpgrades = legacy.map(v => typeof v === 'number' ? idMap[v] : v);
         localStorage.setItem('ownedUpgrades', JSON.stringify(ownedUpgrades));
       }
     }


### PR DESCRIPTION
## Summary
- map numeric `purchasedUpgrades` values to new string ids when loading saved data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c650b57488329a40ad1812ae59a61