### PR TITLE
Add electric pulse on second triple pickup

### DIFF
--- a/index.html
+++ b/index.html
@@ -2892,8 +2892,8 @@ function updateSliceDisks() {
 
 
   function updatePipes(){
-  // only run during normal play
-  if (state !== STATE.Play) return;
+  // only run during play or boss
+  if (state !== STATE.Play && state !== STATE.Boss) return;
 
   const ts = slowMoTimer > 0 ? 0.5 : 1;
 
@@ -2903,8 +2903,8 @@ function updateSliceDisks() {
   const targetSpeed = baseSpeed * Math.pow(1.3, activeBoosts) + pipeCount/200;
   currentSpeed += (targetSpeed - currentSpeed) * 0.05;
 
-  // spawn new pipes when NOT in Mecha
-  if (frames % 90 === 0 && !inMecha) spawnPipe();
+  // spawn new pipes when NOT in Mecha and not during boss
+  if (state === STATE.Play && frames % 90 === 0 && !inMecha) spawnPipe();
 
   // ── pipe movement, scoring & collision ──
   pipes.forEach((p,i) => {
@@ -3082,13 +3082,13 @@ function updateSliceDisks() {
 
       if(Math.hypot(bird.x - p.x, bird.y - p.y) < bird.rad + rocketPowerR){
         p.taken = true;
-        if(rocketPulseUpgrade){
-          if(tripleElectric && electricTimer>0) discModeTimer = 300;
+        if(tripleShot){
           tripleElectric = true;
           electricTimer = 540;
-          // apply electric pulse and advance disc mode if active
+          if(rocketPulseUpgrade && electricTimer>0) discModeTimer = 300;
+        } else {
+          tripleShot = true;
         }
-        tripleShot = true;
         runPowerups++;
         unlockAchievement('rocket3');
         if (runPowerups >= 5) triggerStoryEvent('Rocket_Rite');
@@ -3961,13 +3961,23 @@ if (state === STATE.Boss) {
   // 1) clear the canvas
   ctx.clearRect(0, 0, W, H);
 
-  // 2) redraw your world
+  // 2) redraw your world with effects
+  applyShake();
   drawBackground();
+  updateSkinParticles();
+  updateColumnFlames();
+  updateColumnSnow();
+  updateMoneyLeaves();
   updateBoss();
   updateRockets();
+  updatePipes();
 
   // 3) let the bird respond to gravity/flap
   bird.update();
+  updateReviveEffect();
+  updateDoubleEffect();
+  updateElectricEffect();
+  updateMagnetEffect();
   bird.draw();
 
   // 4) draw the boss on top


### PR DESCRIPTION
## Summary
- trigger electric effect when picking a triple rocket while already powered up
- update pipe logic to run during boss fights so dropped items spawn
- update boss loop to render pickup effects

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684c6907b7fc83298208d20bc8d84bc0