### PR TITLE
Allow boss movement while stunned

### DIFF
--- a/index.html
+++ b/index.html
@@ -1116,7 +1116,7 @@ pipes.length     = apples.length = coins.length = 0;
         electricRings.push({x:p.x,y:p.y,r:30,alpha:0.4,color:'gray'});
       }
       if(frames % 2 === 0) spawnStaggerSpark(p.x, p.y);
-      return;
+      // continue updating so the boss doesn't freeze
     }
     const speedFactor = p.freezeTimer > 0 ? 0 : 1 - p.slowStacks * 0.1;
   if (p.freezeTimer > 0) p.freezeTimer--;


### PR DESCRIPTION
## Summary
- keep boss moving even when stunned so it doesn't freeze up

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684c8662a4348329b80e4bc4cd6787a6