### PR TITLE
Animate default bird sprite

### DIFF
--- a/index.html
+++ b/index.html
@@ -276,6 +276,8 @@
     const ownedSkins = JSON.parse(localStorage.getItem('birdyOwnedSkins')||'{}');
     let defaultSkin = localStorage.getItem('birdySkin') || 'birdieV2.png';
     birdSprite.src = 'assets/' + defaultSkin;
+    const DEFAULT_BIRD_FRAMES = ['assets/birdieV2.png', 'assets/birdieflap.png']
+      .map(src => Object.assign(new Image(), { src }));
     // → New “mecha” states
 const mechaStages = [
   'assets/stage1.png',
@@ -1823,7 +1825,9 @@ function drawBackground(){
           ctx.filter = 'brightness(2)';
         }
         let img = birdSprite;
-        if (defaultSkin === 'cow_down.png' && !birdSprite.src.includes('cow_mech')) {
+        if (defaultSkin === 'birdieV2.png' && birdSprite.src.includes('birdieV2.png')) {
+          img = DEFAULT_BIRD_FRAMES[Math.floor(frames / 6) % DEFAULT_BIRD_FRAMES.length];
+        } else if (defaultSkin === 'cow_down.png' && !birdSprite.src.includes('cow_mech')) {
           img = this.vel < 0 ? cowUpSprite : cowDownSprite;
         }
         ctx.drawImage(img, -32, -32, 64, 64);


### PR DESCRIPTION
## Summary
- animate the basic bird by alternating between `birdieV2.png` and `birdieflap.png`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684c8e6782608329b3e6605675497807