### PR TITLE
Add home menu roulette

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,12 +151,35 @@
     .reel {
       position:absolute; top:12%; bottom:12%; width:33%; overflow:hidden;
     }
-    .reel img, .reel div { position:absolute; width:100%; height:100%;
-      display:flex; align-items:center; justify-content:center; font-size:32px; }
-    .reel:nth-child(2) { left:34%; }
-    .reel:nth-child(3) { left:67%; }
-    .reel:first-child { left:1%; }
-
+    .reel img, .reel div {
+      position:absolute; width:80%; height:80%; left:10%; top:10%;
+      display:flex; align-items:center; justify-content:center; font-size:24px;
+    }
+    .reel:nth-child(1) { left:0%; }
+    .reel:nth-child(2) { left:33%; }
+    .reel:nth-child(3) { left:66%; }
+    #prizeText {
+      font-size:32px; font-weight:bold; margin-top:10px;
+      text-shadow:2px 2px 6px #000;
+    }
+    @keyframes confetti-fall {
+      0% { transform:translateY(-100px) rotate(0); opacity:1; }
+      100% { transform:translateY(300px) rotate(360deg); opacity:0; }
+    }
+    .confetti {
+      position:absolute; width:8px; height:8px; background:var(--c);
+      animation: confetti-fall 1s ease-out forwards;
+      pointer-events:none;
+    }
+    @keyframes firework {
+      from { transform:scale(0); opacity:1; }
+      to   { transform:scale(1.5); opacity:0; }
+    }
+    .firework {
+      position:absolute; width:6px; height:6px; border-radius:50%;
+      background:var(--c); pointer-events:none;
+      animation:firework 0.6s ease-out forwards;
+    }
 
   </style>
 
@@ -190,6 +213,8 @@
        src="assets/dream.guitar.mp3"
        loop
        preload="metadata"></audio>
+  <audio id="spinSound" src="assets/slot_spin.mp3"></audio>
+  <audio id="winSound" src="assets/jackpot.mp3"></audio>
   <canvas id="gameCanvas" width="400" height="600"></canvas>
   <div id="score">0</div>
   <div id="reviveDisplay"><img src="assets/Revive.png" width="24" height="24" style="margin-right:4px;"/><span id="reviveCount">0/1</span></div>
@@ -201,9 +226,10 @@
       <div class="reel"><div></div></div>
       <div class="reel"><div></div></div>
       <div class="reel"><div></div></div>
+    
     </div>
+    <div id="prizeText"></div>
     <div style="margin-top:10px;">
-      <button id="take-coins">Take 20 Coins</button>
       <img src="assets/spin_button.png" id="spin-btn" style="width:80px;cursor:pointer;"/>
     </div>
     <div style="margin-top:10px;">
@@ -217,6 +243,7 @@
     <button id="btnAchievements" class="menu-btn">Achievements</button>
     <button id="btnStory" class="menu-btn">📖 Story Log</button>
     <button id="btnShop" class="menu-btn">Shop</button>
+    <button id="btnDailySpin" class="menu-btn">Daily Spin</button>
   </div>
   <div id="achievementPopup"></div>
   <div id="storyPopup"></div>
@@ -600,6 +627,10 @@ let marathonMoving = false;
     menuEl.style.display = 'none';
     showShop();
   };
+  document.getElementById("btnDailySpin").onclick = () => {
+    menuEl.style.display = "none";
+    showPowerUpSpin(true);
+  };
 
   // boss frames: phase 1 vs. phase 2
   const bossFramesS1 = ['frame0','frame1','frame2']
@@ -707,6 +738,11 @@ const tossBombs   = [];   // upward‐toss bombs
     }
   });
 
+  const spinOverlay = document.getElementById('spinOverlay');
+  spinOverlay.addEventListener('click', () => {
+    if (spinOverlayClickable) closeSpinOverlay();
+  });
+
             
     // ── Audio: background music + SFX context ──
     // dummy chord function (no-op)
@@ -769,6 +805,8 @@ document.addEventListener('keydown',   initMusic, {passive:true});
     const settingsPanel = document.getElementById('settingsPanel');
     const volumeSlider = document.getElementById('volumeSlider');
     volumeSlider.value = globalVolume;
+    const spinSound = document.getElementById("spinSound");
+    const winSound = document.getElementById("winSound");
     function applyVolume() {
       bgMusic.volume = globalVolume;
       mechaMusic.volume = globalVolume;
@@ -807,12 +845,6 @@ document.addEventListener('keydown',   initMusic, {passive:true});
       applyVolume();
     };
 
-    document.getElementById('take-coins').onclick = () => {
-      totalCoins += 20;
-      localStorage.setItem('birdyCoinsEarned', totalCoins);
-      updateScore();
-      closeSpinOverlay();
-    };
 
     document.getElementById('spin-btn').onclick = () => {
       if (totalCoins < 10) {
@@ -919,6 +951,8 @@ const staggerSparks = [];
     const magnetParticles = [];
     let electricTimer = 0;
     let tripleElectric = false;
+    let spinReturnToMenu = false;
+    let spinOverlayClickable = false;
     const electricRings = [];
 
     const symbols = [
@@ -3541,16 +3575,24 @@ function weightedRandomSymbol() {
   return symbols[symbols.length - 1];
 }
 
-function showPowerUpSpin() {
-  const ov = document.getElementById('spinOverlay');
-  ov.style.display = 'block';
-  document.getElementById('take-coins').disabled = false;
-  document.getElementById('spin-btn').style.pointerEvents = 'auto';
+function showPowerUpSpin(returnToMenu=false) {
+  spinReturnToMenu=returnToMenu;
+  const ov=document.getElementById("spinOverlay");
+  ov.style.display="block";
+  document.getElementById("prizeText").textContent="";
+  spinOverlayClickable=false;
+  document.getElementById("spin-btn").style.pointerEvents="auto";
 }
 
 function closeSpinOverlay() {
-  document.getElementById('spinOverlay').style.display = 'none';
-  showOverlay();
+  document.getElementById("spinOverlay").style.display="none";
+  if(spinReturnToMenu){
+    menuEl.style.display="block";
+  }else{
+    showOverlay();
+  }
+  spinReturnToMenu=false;
+  spinOverlayClickable=false;
 }
 
 const reels = [];
@@ -3561,39 +3603,55 @@ function setSymbol(el, sym) {
   el.appendChild(sym.node.cloneNode(true));
 }
 
-function animateReel(el, target, opts) {
-  const start = performance.now();
-  let next = 0;
-  function step(t) {
-    const e = t - start;
-    if (e >= opts.duration) {
-      setSymbol(el, target);
-      return;
-    }
-    if (t >= next) {
-      setSymbol(el, symbols[Math.floor(Math.random() * symbols.length)]);
-      next = t + 50 + e / 5;
+function animateReel(el,target,opts){
+  const start=performance.now();
+  let last=start;
+  function swap(sym){
+    const curr=el.firstElementChild;
+    const next=sym.node.cloneNode(true);
+    next.style.transform="translateY(-100%)";
+    next.style.transition="transform 0.25s linear";
+    curr.style.transition="transform 0.25s linear";
+    el.appendChild(next);
+    requestAnimationFrame(()=>{
+      curr.style.transform="translateY(100%)";
+      next.style.transform="translateY(0)";
+    });
+    next.addEventListener("transitionend",()=>{curr.remove();}, {once:true});
+  }
+  function step(t){
+    const elapsed=t-start;
+    if(elapsed>=opts.duration){swap(target);return;}
+    const delay=120+elapsed/6;
+    if(t-last>delay){
+      swap(symbols[Math.floor(Math.random()*symbols.length)]);last=t;
     }
     requestAnimationFrame(step);
   }
   requestAnimationFrame(step);
 }
-
-function startRoulette() {
-  document.getElementById('spin-btn').style.pointerEvents = 'none';
-  document.getElementById('take-coins').disabled = true;
-  const results = [weightedRandomSymbol(), weightedRandomSymbol(), weightedRandomSymbol()];
-  reels.forEach((r, i) => {
-    animateReel(r, results[i], { duration: 3000 + i * 200 });
+function startRoulette(){
+  document.getElementById("spin-btn").style.pointerEvents="none";
+  const results=[weightedRandomSymbol(),weightedRandomSymbol(),weightedRandomSymbol()];
+  const durations=[4000,6000,8000];
+  spinSound.currentTime=0;
+  spinSound.play().catch(()=>{});
+  reels.forEach((r,i)=>{
+    animateReel(r,results[i],{duration:durations[i]});
   });
-  setTimeout(() => applyReward(results), 3600);
+  const total=Math.max(...durations);
+  setTimeout(()=>{spinSound.pause();spinSound.currentTime=0;applyReward(results);},total+200);
 }
-
-function applyReward(results) {
-  const [a, b, c] = results.map(r => r.id);
-  const id = a === b && b === c ? a : results[1].id;
+function applyReward(results){
+  const [a,b,c]=results.map(r=>r.id);
+  const id=(a===b&&b===c)?a:results[1].id;
   deliverReward(id);
-  closeSpinOverlay();
+  const text=id.replace(/([A-Z])/g," $1").trim();
+  document.getElementById("prizeText").textContent="You won "+text+"!";
+  winSound.currentTime=0;winSound.play().catch(()=>{});
+  showConfetti();
+  showFireworks();
+  spinOverlayClickable=true;
 }
 
 function deliverReward(id) {
@@ -3628,8 +3686,33 @@ function deliverReward(id) {
     localStorage.setItem('birdyCoinsEarned', totalCoins);
     updateScore();
   }
-  showAchievement(`You won: ${id.replace(/([A-Z])/g, ' $1').trim()}`);
 }
+function showConfetti(){
+  const ov=document.getElementById("spinOverlay");
+  for(let i=0;i<20;i++){
+    const d=document.createElement("div");
+    d.className="confetti";
+    d.style.left=Math.random()*100+"%";
+    d.style.background=`hsl(${Math.random()*360},80%,60%)`;
+    d.style.animationDuration=0.8+Math.random()*0.7+"s";
+    ov.appendChild(d);
+    d.addEventListener("animationend",()=>d.remove());
+  }
+}
+
+function showFireworks(){
+  const ov=document.getElementById('spinOverlay');
+  for(let i=0;i<20;i++){
+    const d=document.createElement('div');
+    d.className='firework';
+    d.style.left=40+Math.random()*20+'%';
+    d.style.top=30+Math.random()*40+'%';
+    d.style.background=`hsl(${Math.random()*360},80%,60%)`;
+    ov.appendChild(d);
+    d.addEventListener('animationend',()=>d.remove());
+  }
+}
+
 
 function showRevivePrompt(){
   if (revivePromptActive || usedRevive) return false;


### PR DESCRIPTION
## Summary
- enable roulette from home screen via new **Daily Spin** button
- refactor spin overlay behavior so it can return to menu
- animate slot reels with sliding motion and sequential stop timing
- display prize text with confetti and sound effects
- add spin sound assets and big win audio

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684cfe6eac888329bb40ade85961f8f7