### PR TITLE
Fix slot reel sync and reduce sky island clutter

### DIFF
--- a/index.html
+++ b/index.html
@@ -353,13 +353,17 @@ const bgLayers = {
 }; 
 
 const bgConfigs = [
-  { img: bgLayers.distant2, scale: 1/3, speed: 0.2, alpha: 1, yMin: () => ORIGINAL_HEIGHT*0.45, yMax: () => ORIGINAL_HEIGHT*0.55 },
-  { img: bgLayers.distant1, scale: 1/3, speed: 0.25, alpha: 1, yMin: () => ORIGINAL_HEIGHT*0.45, yMax: () => ORIGINAL_HEIGHT*0.55 },
+  { img: bgLayers.distant2, scale: 1/6, speed: 0.2, alpha: 1, gap: 2,
+    yMin: () => ORIGINAL_HEIGHT*0.45, yMax: () => ORIGINAL_HEIGHT*0.55 },
+  { img: bgLayers.distant1, scale: 1/6, speed: 0.25, alpha: 1, gap: 2,
+    yMin: () => ORIGINAL_HEIGHT*0.45, yMax: () => ORIGINAL_HEIGHT*0.55 },
   { img: bgLayers.cloud3,   scale: 0.5, speed: 0.4, alpha: 0.6, yMin: () => 0,              yMax: () => ORIGINAL_HEIGHT*0.4  },
   { img: bgLayers.cloud2,   scale: 0.5, speed: 0.6, alpha: 0.6, yMin: () => 0,              yMax: () => ORIGINAL_HEIGHT*0.4  },
   { img: bgLayers.cloud1,   scale: 0.5, speed: 0.8, alpha: 0.6, yMin: () => 0,              yMax: () => ORIGINAL_HEIGHT*0.4  },
-  { img: bgLayers.island2,  scale: 0.5, speed: 1.0, alpha: 1, yMin: () => ORIGINAL_HEIGHT*0.5, yMax: () => ORIGINAL_HEIGHT*0.8 },
-  { img: bgLayers.island1,  scale: 0.5, speed: 1.2, alpha: 1, yMin: () => ORIGINAL_HEIGHT*0.5, yMax: () => ORIGINAL_HEIGHT*0.8 }
+  { img: bgLayers.island2,  scale: 0.25, speed: 1.0, alpha: 1, gap: 2,
+    yMin: () => ORIGINAL_HEIGHT*0.5, yMax: () => ORIGINAL_HEIGHT*0.8 },
+  { img: bgLayers.island1,  scale: 0.25, speed: 1.2, alpha: 1, gap: 2,
+    yMin: () => ORIGINAL_HEIGHT*0.5, yMax: () => ORIGINAL_HEIGHT*0.8 }
 ];
 let bgSprites = [];
 
@@ -367,11 +371,12 @@ function initBackgroundSprites() {
   bgSprites.length = 0;
   bgConfigs.forEach(cfg => {
     const w = (cfg.img.width || ORIGINAL_WIDTH) * cfg.scale;
-    const count = Math.ceil(ORIGINAL_WIDTH / w) + 1;
+    const spacing = w * (cfg.gap || 1);
+    const count = Math.ceil(ORIGINAL_WIDTH / spacing) + 1;
     for (let i = 0; i < count; i++) {
       bgSprites.push({
         cfg,
-        x: i * w,
+        x: i * spacing,
         y: cfg.yMin() + Math.random() * (cfg.yMax() - cfg.yMin())
       });
     }
@@ -1909,7 +1914,8 @@ function drawBackground(){
     if (sp.x + w < 0) {
       const same = bgSprites.filter(o => o.cfg === sp.cfg);
       const maxX = Math.max(...same.map(o => o.x));
-      sp.x = maxX + w + Math.random() * 20;
+      const spacing = w * (sp.cfg.gap || 1);
+      sp.x = maxX + spacing;
       sp.y = sp.cfg.yMin() + Math.random() * (sp.cfg.yMax() - sp.cfg.yMin());
     }
     ctx.save();
@@ -3628,7 +3634,7 @@ function animateReel(el,target,opts){
   function step(t){
     const elapsed=t-start;
     if(elapsed>=opts.duration){swap(target);return;}
-    const delay=120+elapsed/6;
+    const delay=250+elapsed/6;
     if(t-last>delay){
       swap(symbols[Math.floor(Math.random()*symbols.length)]);last=t;
     }


### PR DESCRIPTION
## Summary
- shrink sky islands and space them further apart
- avoid overlapping swaps in reel animation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684dcce54f148329a7d48629881493cb