### PR TITLE
Fix night overlay artifact on islands

### DIFF
--- a/index.html
+++ b/index.html
@@ -1930,7 +1930,9 @@ function drawBackground(){
     ctx.drawImage(img, sp.x, sp.y, w, h);
     if (islandImages.has(img)) {
       ctx.fillStyle = `rgba(0,30,60,${wN*0.5})`;
+      ctx.globalCompositeOperation = 'source-atop';
       ctx.fillRect(sp.x, sp.y, w, h);
+      ctx.globalCompositeOperation = 'source-over';
     }
     ctx.restore();
   });


### PR DESCRIPTION
## Summary
- avoid square artifacts around islands at night by using `source-atop`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684eedf4f3b083299250bf90cf6ffd82