### PR TITLE
Fix sky island tint overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -1928,14 +1928,12 @@ function drawBackground(){
     ctx.save();
     ctx.globalAlpha = sp.cfg.alpha;
     ctx.drawImage(img, sp.x, sp.y, w, h);
-    if (islandImages.has(img)) {
-      ctx.fillStyle = `rgba(0,30,60,${wN*0.5})`;
-      ctx.globalCompositeOperation = 'source-atop';
-      ctx.fillRect(sp.x, sp.y, w, h);
-      ctx.globalCompositeOperation = 'source-over';
-    }
     ctx.restore();
   });
+  ctx.save();
+  ctx.fillStyle = `rgba(0,30,60,${wN*0.5})`;
+  ctx.fillRect(0, 0, W, H);
+  ctx.restore();
 
   // 3) sun / moon path
   const sunR  = 30, moonR = 25;


### PR DESCRIPTION
## Summary
- remove per-island tint logic
- add single global tint layer driven by day/night cycle

## Testing
- `npx --yes htmlhint index.html` *(fails: The id value [ bgMusic ] must be unique)*

------
https://chatgpt.com/codex/tasks/task_e_684ef62803888329b5d1d65aa536581a