### PR TITLE
Enhance sonar effect and force score entry

### DIFF
--- a/index.html
+++ b/index.html
@@ -3135,11 +3135,13 @@ function updateBatSwarms(){
 function updateSonarRings(){
   for(let i=sonarRings.length-1;i>=0;i--){
     const r = sonarRings[i];
-    r.r += 2;
-    r.alpha -= 0.03;
+    r.r += 3;
+    r.alpha -= 0.02;
     ctx.save();
     ctx.strokeStyle = `rgba(0,150,255,${r.alpha})`;
-    ctx.lineWidth = 2;
+    ctx.lineWidth = 3;
+    ctx.shadowBlur = 8;
+    ctx.shadowColor = `rgba(0,150,255,${r.alpha})`;
     ctx.beginPath();
     ctx.arc(r.x, r.y, r.r, 0, Math.PI*2);
     ctx.stroke();
@@ -4032,7 +4034,7 @@ function updateSliceDisks() {
           c.y += dy * 0.1;
           if(frames % 4 === 0) spawnMagnetParticle(c.x, c.y);
           if(batAttract && frames % 6 === 0){
-            sonarRings.push({ x: bird.x, y: bird.y, r: 10, alpha: 0.5 });
+            sonarRings.push({ x: bird.x, y: bird.y, r: 10, alpha: 0.8 });
           }
         }
       }
@@ -4319,7 +4321,7 @@ function finalizeGameOver(){
   }
 
   playTone(100, 0.3);
-  menuEl.style.display = 'block';
+  showOverlay();
   if (gauntletMode) resetGame();
 }
 
@@ -4454,11 +4456,11 @@ function closeSpinOverlay() {
     prevMusic.play().catch(()=>{});
     prevMusic = null;
   }
-  if(spinReturnToMenu){
+  if(state===STATE.Over){
+    showOverlay();
+  } else if(spinReturnToMenu){
     menuEl.style.display="block";
     resetGame();
-  }else{
-    showOverlay();
   }
   spinReturnToMenu=false;
   spinForRevive=false;
@@ -4694,7 +4696,6 @@ function showRevivePrompt(){
       showPowerUpSpin(false, true);
     } else if(action === 'menu') {
       finalizeGameOver();
-      resetGame();
     } else {
       finalizeGameOver();
     }


### PR DESCRIPTION
## Summary
- make sonar rings larger with glow
- trigger score overlay when the game ends
- show score overlay after casino spin
- ensure menu option in revive prompt shows the scoreboard

## Testing
- `npx htmlhint index.html` *(fails: htmlhint not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68536c3471f48329a93fa127b486c711