### PR TITLE
Use new icons for upgrades

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,10 +265,34 @@
       box-shadow:var(--menu-shadow);
       text-align:center;
     }
-    #upgradeTree { position:relative; width:100%; height:100%; }
-    #upgradeLines { position:absolute; top:0; left:0; width:100%; height:100%; pointer-events:none; }
-    .upgradeNode { position:absolute; width:40px; height:40px; border-radius:50%; display:flex; align-items:center; justify-content:center; flex-direction:column; font-size:10px; color:#fff; border:2px solid; transform:translate(-50%,-50%); }
-    .lineGlow { filter: drop-shadow(0 0 4px currentColor); }
+    #upgradeTree {
+      display:grid;
+      grid-template-columns:repeat(auto-fill, minmax(60px, 1fr));
+      gap:12px;
+      justify-items:center;
+      width:100%;
+      padding:10px 0;
+    }
+    .upgradeNode {
+      position:relative;
+      width:36px;
+      height:36px;
+      border-radius:50%;
+      border:2px solid;
+    }
+    .upgradeNode img { width:100%; height:100%; border-radius:50%; }
+    .upgradeNode.equipped { width:48px; height:48px; }
+    .upgradeNode.locked img { filter:grayscale(1) brightness(0.4); }
+    .upgradeNode.owned img { filter:grayscale(0.7) brightness(0.7); }
+    .priceTag {
+      position:absolute;
+      bottom:-14px;
+      width:100%;
+      text-align:center;
+      font-size:12px;
+      color:#fff;
+      pointer-events:none;
+    }
 
     #btnSettings {
       position:absolute;
@@ -1558,6 +1582,7 @@ const batSwarms = [];
             effect: () => { coinSpawnBonus += 0.10; },
             costFactor: 1,
             tier: 0,
+            icon: 'coins10up.png',
             x: 0,
             y: 0
           },
@@ -1569,6 +1594,7 @@ const batSwarms = [];
             costFactor: 1.1,
             tier: 1,
             parent: 'natural_coin10',
+            icon: 'coins10up.png',
             x: -1,
             y: 1
           },
@@ -1580,6 +1606,7 @@ const batSwarms = [];
             costFactor: 1.2,
             tier: 1,
             parent: 'natural_coin10',
+            icon: 'magnetup.png',
             x: 1,
             y: 1
           },
@@ -1591,6 +1618,7 @@ const batSwarms = [];
             costFactor: 1.2,
             tier: 2,
             parent: 'natural_magnet',
+            icon: 'magnetup.png',
             x: 1,
             y: 2
           }
@@ -1613,6 +1641,7 @@ const batSwarms = [];
             },
             costFactor: 1,
             tier: 0,
+            icon: 'big_rocket.png',
             x: 3,
             y: 0
           },
@@ -1624,6 +1653,7 @@ const batSwarms = [];
             costFactor: 1.3,
             tier: 1,
             parent: 'mech_rocket_big',
+            icon: 'splash_damage.png',
             x: 3,
             y: 1
           },
@@ -1635,6 +1665,7 @@ const batSwarms = [];
             costFactor: 1.4,
             tier: 2,
             parent: 'mech_rocket_splash',
+            icon: 'pulse_rocket.png',
             x: 3,
             y: 2
           }
@@ -5163,8 +5194,8 @@ function showShop() {
         html += `</div>`;
       });
     } else if(section==='upgrades') {
-      html += `<div id="upgradeTreeWrap" style="position:relative;margin-top:10px;width:100%;height:calc(100% - 60px);">`+
-              `<svg id="upgradeLines"></svg><div id="upgradeTree"></div></div>`+
+      html += `<div id="upgradeTreeWrap" style="margin-top:10px;width:100%;height:calc(100% - 60px);overflow-y:auto;">`+
+              `<div id="upgradeTree"></div>`+
 
               `<div id="upgradeStats" style="position:absolute;text-align:center;font-size:14px;"></div>`+
               `</div>`;
@@ -5248,14 +5279,8 @@ function showShop() {
 }
 
 function renderUpgradeTree() {
-  const tree   = document.getElementById("upgradeTree");
-  const lines  = document.getElementById("upgradeLines");
+  const tree = document.getElementById("upgradeTree");
   tree.innerHTML = "";
-  lines.innerHTML = "";
-  const gridX = 80;
-  const gridY = 80;
-  const center = tree.offsetWidth / 2;
-  const pos = {};
 
   upgradeTreeConfig.forEach(branch => {
     branch.upgrades.forEach(upg => {
@@ -5264,19 +5289,23 @@ function renderUpgradeTree() {
       const equipped = equippedUpgrades.includes(upg.id);
       const node = document.createElement("div");
       node.className = "upgradeNode";
+      if(equipped) node.classList.add("equipped");
+      else if(owned) node.classList.add("owned");
+      else node.classList.add("locked");
       node.style.borderColor = branch.color;
-      node.style.background = equipped ? "#fff" : owned ? branch.color : "#333";
-      node.style.left = (center + upg.x * gridX) + "px";
-      node.style.top  = (40 + upg.y * gridY) + "px";
-      node.textContent = owned ? (equipped ? "★" : "✓") : cost;
-      if(upg.id.includes("coin") || upg.id.includes("rocket") || upg.id.includes("magnet")){
-        const icon = document.createElement("div");
-        icon.className = "iconBounce";
-        icon.style.fontSize = "16px";
-        icon.textContent = upg.id.includes("coin") ? "🪙" : upg.id.includes("rocket") ? "🚀" : "🧲";
-        node.prepend(icon);
+
+      const img = document.createElement("img");
+      img.src = "assets/" + upg.icon;
+      img.className = "iconBounce";
+      node.appendChild(img);
+
+      if(!owned){
+        const price = document.createElement("div");
+        price.className = "priceTag";
+        price.textContent = cost + ' 🪙';
+        node.appendChild(price);
       }
-      if(!owned) node.style.cursor = "pointer";
+      node.style.cursor = "pointer";
       node.addEventListener("mouseenter", () => { showTooltip(upg.name+": "+upg.description); });
       node.addEventListener("mouseleave", hideTooltip);
       node.addEventListener("click", () => {
@@ -5317,33 +5346,6 @@ function renderUpgradeTree() {
         }
       });
       tree.appendChild(node);
-      pos[upg.id] = { node, branch, upg };
-    });
-  });
-
-  requestAnimationFrame(() => {
-    const treeRect = tree.getBoundingClientRect();
-    lines.setAttribute('width', treeRect.width);
-    lines.setAttribute('height', treeRect.height);
-    Object.values(pos).forEach(({node, upg, branch}) => {
-      if (!upg.parent) return;
-      const parent = pos[upg.parent];
-      if(!parent) return;
-      const a = parent.node.getBoundingClientRect();
-      const b = node.getBoundingClientRect();
-      const line = document.createElementNS('http://www.w3.org/2000/svg','line');
-      line.setAttribute('x1', a.left - treeRect.left + a.width/2);
-      line.setAttribute('y1', a.top - treeRect.top + a.height/2);
-      line.setAttribute('x2', b.left - treeRect.left + b.width/2);
-      line.setAttribute('y2', b.top - treeRect.top + b.height/2);
-      line.setAttribute('stroke', branch.color);
-      line.setAttribute('stroke-width', 3);
-      if (ownedUpgrades.includes(upg.parent) && ownedUpgrades.includes(upg.id)) {
-        line.classList.add('lineGlow');
-      } else {
-        line.style.opacity = 0.3;
-      }
-      lines.appendChild(line);
     });
   });
 }


### PR DESCRIPTION
## Summary
- style upgrade nodes with icon images instead of text
- map each upgrade to its png asset
- show cost beneath locked upgrades
- enlarge equipped upgrades
- simplify upgrade view into a grid

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6853796046b48329a7519f690c24b470