### PR TITLE
Fix duplicate upgrade text

### DIFF
--- a/index.html
+++ b/index.html
@@ -5298,8 +5298,6 @@ function renderUpgradeTree() {
         node.appendChild(price);
       }
       node.style.cursor = "pointer";
-      node.addEventListener("mouseenter", () => { showTooltip(upg.name+": "+upg.description); });
-      node.addEventListener("mouseleave", hideTooltip);
       node.addEventListener("click", () => {
         if (!owned) {
           if (upg.parent && !ownedUpgrades.includes(upg.parent)) {


### PR DESCRIPTION
## Summary
- remove upgrade tooltip from node hover events

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68542d634f6483298762ecac00193606