### PR TITLE
Fix upgrade slot icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -1620,7 +1620,7 @@ const batSwarms = [];
             costFactor: 1.2,
             tier: 2,
             parent: 'natural_magnet',
-            icon: 'magnetup.png',
+            icon: 'doubleup.png',
             x: 1,
             y: 2
           }


### PR DESCRIPTION
## Summary
- use `doubleup.png` for the slot-increasing upgrade

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68544d548aa88329bb31a5420d017ff3