### PR TITLE
Fix outside-click reset after game over

### DIFF
--- a/index.html
+++ b/index.html
@@ -1205,6 +1205,22 @@ const tossBombs   = [];   // upward‐toss bombs
     }
   });
 
+  function outsideScreenHandler(e) {
+    if (state === STATE.Over && !overlay.contains(e.target)) {
+      if (!hasSubmittedScore) {
+        saveGlobalScore('Anon', score);
+        trackEvent('submit_score', { score });
+        hasSubmittedScore = true;
+      }
+      if (!overlayTop10Lock) {
+        overlay.style.display = 'none';
+        resetGame();
+      }
+    }
+  }
+  document.addEventListener('mousedown', outsideScreenHandler);
+  document.addEventListener('touchstart', outsideScreenHandler, { passive:true });
+
   const spinOverlay = document.getElementById('spinOverlay');
   const coinDisplay = document.getElementById('coinDisplay');
   const spinCoinDisplay = document.getElementById('spinCoinDisplay');


### PR DESCRIPTION
## Summary
- ensure clicking outside the overlay after a game ends works like Main Menu

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685478f0c8c48329bba866a11d7ed777