### PR TITLE
Add shock drop power-up with electric effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -1479,6 +1479,7 @@ let altMechaTimer = 0;
     const rocketsIn  = [];
     const rocketPowerups = [];
     const rocketSymbols = [];
+    const shockDrops = [];
 const rocketParticles = [];
 const rocketSmoke = [];
 const rocketFlames = [];
@@ -1579,6 +1580,7 @@ const pulseRings = [];
     }
 
     const electricRings = [];
+    const electricBolts = [];
 
     const symbols = [
       { id: 'Revive',        icon: 'assets/Revive.png',       weight: 10 },
@@ -2997,6 +2999,7 @@ function spawnExplosion(x, y, fromRocket = false, electric = false) {
     triggerShake(8);
     electricRings.push({ x, y, r: 20, alpha: 0.8, color: 'cyan' });
     electricRings.push({ x, y, r: 20, alpha: 0.8, color: 'magenta' });
+    spawnElectricLines(x, y);
     for(let jj=jellies.length-1;jj>=0;jj--){
       const j=jellies[jj];
       if(Math.hypot(j.x-x,j.y-y)<40){
@@ -3008,6 +3011,7 @@ function spawnExplosion(x, y, fromRocket = false, electric = false) {
         j.hp = (j.hp||1) - 1;
         if(j.hp<=0){
           jellies.splice(jj,1);
+          maybeDropShock(j.x,j.y);
           runJellies++;
           if(runJellies>=5) unlockAchievement('kill5');
           if(runJellies>=10) triggerStoryEvent('Jelly_Vanquished');
@@ -3122,6 +3126,39 @@ function updateMilkParticles() {
     ctx.fill();
     ctx.restore();
     if (m.life <= 0) milkParticles.splice(i,1);
+  }
+}
+
+function spawnElectricLines(x, y){
+  for(let b=0;b<3;b++){
+    const pts=[];
+    const len=40+Math.random()*20;
+    let px=x, py=y, ang=Math.random()*Math.PI*2;
+    for(let s=0;s<5;s++){
+      ang += (Math.random()-0.5)*0.5;
+      px += Math.cos(ang)*len/5;
+      py += Math.sin(ang)*len/5;
+      pts.push({x:px,y:py});
+    }
+    electricBolts.push({x, y, pts, life:60, color:Math.random()<0.5?'cyan':'magenta'});
+  }
+}
+
+function updateElectricBolts(){
+  for(let i=electricBolts.length-1;i>=0;i--){
+    const b=electricBolts[i];
+    b.life--;
+    const alpha=Math.sin((b.life/60)*Math.PI);
+    ctx.save();
+    const col=b.color==='cyan'?'0,255,255':'255,0,255';
+    ctx.strokeStyle=`rgba(${col},${alpha})`;
+    ctx.lineWidth=2+2*alpha;
+    ctx.beginPath();
+    ctx.moveTo(b.x,b.y);
+    b.pts.forEach(p=>ctx.lineTo(p.x,p.y));
+    ctx.stroke();
+    ctx.restore();
+    if(b.life<=0) electricBolts.splice(i,1);
   }
 }
 
@@ -3398,6 +3435,12 @@ function spawnMoneyLeaf(x, y, vx, vy) {
 function maybeDropCoin(x, y){
   if (isStorySkin() && Math.random() < 0.15) {
     coins.push({ x, y, taken:false });
+  }
+}
+
+function maybeDropShock(x, y){
+  if(Math.random() < 0.5){
+    shockDrops.push({ x, y, frame:0, taken:false });
   }
 }
 
@@ -3772,6 +3815,7 @@ function updateRockets() {
         if (r.type === 'ice') j.slowStacks = Math.min(j.slowStacks + 1, 5);
         if (j.hp <= 0) {
           jellies.splice(jj, 1);
+          maybeDropShock(j.x, j.y);
           runJellies++;
           if (runJellies >= 5) unlockAchievement('kill5');
           if (runJellies >= 10) triggerStoryEvent('Jelly_Vanquished');
@@ -4049,6 +4093,7 @@ for (let i = stage2Bombs.length - 1; i >= 0; i--) {
   updateImpactParticles();
   updateStaggerSparks();
   updateMilkParticles();
+  updateElectricBolts();
 }
 
 function updateJellies() {
@@ -4120,7 +4165,7 @@ function updateJellies() {
     if (j.burnTimer > 0) {
       j.burnTimer--;
       if (frames % 30 === 0) j.hp--;
-      if (j.hp <= 0) { jellies.splice(i,1); continue; }
+      if (j.hp <= 0) { maybeDropShock(j.x,j.y); jellies.splice(i,1); continue; }
     }
     if (j.slowStacks === 5 && j.freezeTimer === 0 && Math.random() < 0.02) {
       j.freezeTimer = 60;
@@ -4175,7 +4220,7 @@ function updateSliceDisks() {
         spawnExplosion(j.x,j.y);
         j.hp=(j.hp||1)-(d.damage||1);
           j.flashTimer=6;
-          if(j.hp<=0){ jellies.splice(jj,1); runJellies++; if(runJellies>=5) unlockAchievement('kill5'); }
+          if(j.hp<=0){ jellies.splice(jj,1); maybeDropShock(j.x,j.y); runJellies++; if(runJellies>=5) unlockAchievement('kill5'); }
           d.hp=0;
           break;
         }
@@ -4417,6 +4462,42 @@ function updateCheeseKiller() {
   if (c.x + coinR < 0 || c.taken) coins.splice(i, 1);
 });
 
+  // ── shock drop pickup ──
+  shockDrops.forEach((p,i)=>{
+    const spd = baseSpeed * 0.6 * (inMecha ? 0.66 : 1);
+    p.x -= spd * ts;
+    p.frame++;
+    if(!p.taken){
+      const img = jellyFrames[Math.floor(p.frame/8)%jellyFrames.length];
+      const shockImg = jellyShockFrames[Math.floor(p.frame/4)%jellyShockFrames.length];
+      ctx.save();
+      ctx.translate(p.x, p.y + Math.sin(frames*0.1)*2);
+      ctx.drawImage(img, -8, -8, 16, 16);
+      for(let a=0;a<4;a++){
+        const ang=a*Math.PI/2+frames*0.1;
+        ctx.drawImage(shockImg, Math.cos(ang)*20-8, Math.sin(ang)*20-8,16,16);
+      }
+      ctx.restore();
+      ctx.save();
+      ctx.textAlign='center';
+      ctx.fillStyle='#fff';
+      ctx.font='12px sans-serif';
+      ctx.fillText('Shock', p.x, p.y-18);
+      ctx.restore();
+      ctx.strokeStyle='rgba(255,255,255,0.5)';
+      ctx.beginPath();
+      ctx.arc(p.x,p.y,12,0,Math.PI*2);
+      ctx.stroke();
+      if(Math.hypot(bird.x-p.x,bird.y-p.y)<bird.rad+12){
+        p.taken=true;
+        tripleElectric=true;
+        electricTimer=300;
+        addEffectIcon('shock','assets/jelly1.png');
+      }
+    }
+    if(p.x< -20 || p.taken) shockDrops.splice(i,1);
+  });
+
   // ── triple rocket powerup pickup ──
   rocketPowerups.forEach((p,i)=>{
     const powerSpeed = baseSpeed * 0.6 * (inMecha ? 0.66 : 1);
@@ -4437,6 +4518,12 @@ function updateCheeseKiller() {
       for(let j=0;j<3;j++){
         ctx.drawImage(img, -8, -12 + j*8, 16, 16);
       }
+      ctx.restore();
+      ctx.save();
+      ctx.textAlign='center';
+      ctx.fillStyle='#fff';
+      ctx.font='12px sans-serif';
+      ctx.fillText(tripleShot ? 'Pulse' : 'Triple', p.x, p.y-18);
       ctx.restore();
 
       if(frames % 4 === 0){
@@ -5808,6 +5895,7 @@ if (state === STATE.BossExplode) {
   updateImpactParticles();
   updateStaggerSparks();
   updateMilkParticles();
+  updateElectricBolts();
   updateElectricEffect();
   updateBatThrust();
   updateBatSwarms();


### PR DESCRIPTION
## Summary
- spawn small jellyfish power-up when a jelly dies
- picking up the shock drop grants temporary electric rockets
- render random electric bolts on explosions
- label rocket power-up and shock drop for clarity

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6861ebb218f483298a9e46041e47d45c