### PR TITLE
Add menu music toggle and hide auto leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@
     .menu-btn.primary.adventure { background-image: linear-gradient(to bottom, #8BC34A, #558B2F); }
     .menu-btn.primary.marathon  { background-image: linear-gradient(to bottom, #4FC3F7, #0288D1); }
     .menu-btn.primary.gauntlet  { background-image: linear-gradient(to bottom, #EF5350, #C62828); }
+    .menu-btn.primary.music     { background-image: linear-gradient(to bottom, #FFCA28, #F57C00); }
 
     .menu-row {
       display:grid;
@@ -535,6 +536,7 @@
 
     <button id="btnMarathon" class="menu-btn primary marathon">∞ Marathon</button>
     <button id="btnGauntlet" class="menu-btn primary gauntlet">⚔️ Gauntlet</button>
+    <button id="btnMusicToggle" class="menu-btn primary music">🎵 Music: On</button>
 
     <div class="menu-row">
       <button id="btnAchievements" class="menu-btn secondary">


### PR DESCRIPTION
## Summary
- Add persistent music toggle button on the home menu to mute or resume game music.
- Remove automatic leaderboard fetch so scores only show when requested.

## Testing
- `npm test` *(fails: package.json not found)*
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68b9dced2ed08329b2dd76f4943be6fe