### PR TITLE
Add Option Trading Hero page link and back navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -484,7 +484,8 @@
     <div class="logo">Aviar — Rocket Birdie</div>
     <div class="hamburger" id="burger">☰</div>
     <nav id="navLinks">
-      <a href="/index.html">Play</a>
+      <a href="/index.html">Birdie</a>
+      <a href="./option-trading-hero/index.html">Trading Hero</a>
       <a href="/how-to-play.html">How to Play</a>
       <a href="/changelog.html">Changelog</a>
       <a href="/about.html">About</a>

--- a/option-trading-hero/index.html
+++ b/option-trading-hero/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <a class="back-link" href="../index.html">← Back to Birdie</a>
   <div id="app">
     <div id="topbar">
       <div class="brand">

--- a/option-trading-hero/style.css
+++ b/option-trading-hero/style.css
@@ -27,6 +27,25 @@ body {
     radial-gradient(circle at 50% 100%, rgba(32,255,157,.08), transparent 40%),
     linear-gradient(180deg, var(--bg0), var(--bg1));
 }
+
+.back-link {
+  position: fixed;
+  top: 10px;
+  left: 10px;
+  z-index: 100;
+  display: inline-block;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,.2);
+  color: var(--text);
+  text-decoration: none;
+  background: rgba(2, 8, 16, .7);
+  backdrop-filter: blur(8px);
+  box-shadow: 0 8px 20px rgba(0,0,0,.25);
+}
+.back-link:hover {
+  border-color: rgba(0,229,255,.45);
+}
 button, select, input { font: inherit; }
 button {
   border: 1px solid rgba(255,255,255,.13);


### PR DESCRIPTION
### Motivation
- Integrate the existing Option Trading Hero game as a separate playable static page reachable from the Birdie site without changing Birdie as the default/home page.

### Description
- Add a visible "Trading Hero" navigation link to the site header by updating `index.html` and rename the previous "Play" link to "Birdie" so the menu is explicit.
- Add a top-left "← Back to Birdie" anchor in `option-trading-hero/index.html` and provide scoped styles for it in `option-trading-hero/style.css` so the UI is navigable and styling stays contained to the trading folder.
- Preserve all Trading Hero CSS/JS/assets under `/option-trading-hero/` and avoid touching Birdie game logic or global styles.
- Files changed: `index.html` (add nav link / rename Play→Birdie), `option-trading-hero/index.html` (insert back link), and `option-trading-hero/style.css` (scoped styling for back link).

### Testing
- Ran automated file-existence checks and content searches (`test -f` and `rg`) to confirm the new nav link, back link, and music references are present, and these checks passed.
- Verified via `git diff` inspection and reading `option-trading-hero/game.js` that music paths remain relative (`music/...`) and that the navigation paths `./option-trading-hero/index.html` and `../index.html` will resolve on static GitHub Pages, and these verifications succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0284697320832991babd52ba46cf02)